### PR TITLE
WEKA: At StopAtEnd for completion scrolling.

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -37,6 +37,7 @@ type CompletionManager struct {
 	wordSeparator  string
 	showAtStart    bool
 	autoComplete   bool
+	stopAtEnd      bool
 }
 
 // GetSelectedSuggestion returns the selected item.
@@ -80,20 +81,24 @@ func (c *CompletionManager) UpdateNext(in Document) {
 
 // Select the previous suggestion item.
 func (c *CompletionManager) Previous() {
-	if c.verticalScroll == c.selected && c.selected > 0 {
-		c.verticalScroll--
+	if c.selected > 0 || !c.stopAtEnd {
+		if c.verticalScroll == c.selected && c.selected > 0 {
+			c.verticalScroll--
+		}
+		c.selected--
+		c.update()
 	}
-	c.selected--
-	c.update()
 }
 
 // Next to select the next suggestion item.
 func (c *CompletionManager) Next() int {
-	if c.verticalScroll+int(c.max)-1 == c.selected {
-		c.verticalScroll++
+	if c.selected < len(c.tmp)-1 || !c.stopAtEnd {
+		if c.verticalScroll+int(c.max)-1 == c.selected {
+			c.verticalScroll++
+		}
+		c.selected++
+		c.update()
 	}
-	c.selected++
-	c.update()
 	return c.selected
 }
 

--- a/constructor.go
+++ b/constructor.go
@@ -270,6 +270,15 @@ func WithShowCompletionAtStart() Option {
 	}
 }
 
+// WithStopCompletionAtEnd to prevent nagivating off the end of the completion list.
+// This will keep the cursor where it is on the completion menu.  (Use ESC to leave it.)
+func WithStopCompletionAtEnd() Option {
+	return func(p *Prompt) error {
+		p.completion.stopAtEnd = true
+		return nil
+	}
+}
+
 // WithBreakLineCallback to run a callback at every break line
 func WithBreakLineCallback(fn func(*Document)) Option {
 	return func(p *Prompt) error {


### PR DESCRIPTION
This implements a simple limiter option to control the interactive mode scrolling -- this is per WEKAPP-535049.

I've tested this in a local build of wekactl and will have a PR that uses this coming shortly.  Once this goes in, I'll update the tag to v0.0.3 as well.