### PR TITLE
weka: Hide inactive completions

### DIFF
--- a/_example/http-prompt/main.go
+++ b/_example/http-prompt/main.go
@@ -191,6 +191,7 @@ func main() {
 		prompt.WithPrefixCallback(livePrefix(u.String()+"> ")),
 		prompt.WithTitle("http-prompt"),
 		prompt.WithCompleter(completer),
+		prompt.WithHideInactiveCompletion(),
 	)
 	p.Run()
 }

--- a/_example/simple-echo/main.go
+++ b/_example/simple-echo/main.go
@@ -30,6 +30,7 @@ func main() {
 		prompt.WithSelectedSuggestionBGColor(prompt.LightGray),
 		prompt.WithSuggestionBGColor(prompt.DarkGray),
 		prompt.WithCompleter(completer),
+		prompt.WithHideInactiveCompletion(),
 	)
 	fmt.Println("Your input: " + in)
 }

--- a/constructor.go
+++ b/constructor.go
@@ -279,6 +279,14 @@ func WithStopCompletionAtEnd() Option {
 	}
 }
 
+// WithHideInactiveCompletion to prevent showing the completions unless actively completing.
+func WithHideInactiveCompletion() Option {
+	return func(p *Prompt) error {
+		p.renderer.hideInactive = true
+		return nil
+	}
+}
+
 // WithBreakLineCallback to run a callback at every break line
 func WithBreakLineCallback(fn func(*Document)) Option {
 	return func(p *Prompt) error {

--- a/renderer.go
+++ b/renderer.go
@@ -21,6 +21,7 @@ type Renderer struct {
 	indentSize        int  // How many spaces constitute a single indentation level
 	maskRune          rune // display the given character instead of the entry (masked password)
 	noEcho            bool // display nothing (except the prefix) at all (more secure)
+	hideInactive      bool // hide suggestions when not completing
 
 	previousCursor Position
 
@@ -115,6 +116,7 @@ func (r *Renderer) renderCompletion(buf *Buffer, completions *CompletionManager)
 	if len(suggestions) == 0 {
 		return
 	}
+
 	prefix := r.prefixCallback()
 	prefixWidth := istrings.GetWidth(prefix)
 	formatted, width := formatSuggestions(
@@ -231,7 +233,9 @@ func (r *Renderer) Render(buffer *Buffer, completion *CompletionManager, lexer L
 	// Log("col: %#v, targetCursor: %#v, cursor: %#v\n", col, targetCursor, cursor)
 	cursor = r.move(cursor, targetCursor)
 
-	r.renderCompletion(buffer, completion)
+	if completion.Completing() || !r.hideInactive {
+		r.renderCompletion(buffer, completion)
+	}
 	r.previousCursor = cursor
 }
 


### PR DESCRIPTION
This allows the suggestion window to start and remain hidden when not performing active completions, which is closer to the typical UNIX shell experience.